### PR TITLE
fix: incorrect serialization of Signal<ClassList>

### DIFF
--- a/apps/personal-website/src/utils/serializeClass.ts
+++ b/apps/personal-website/src/utils/serializeClass.ts
@@ -1,5 +1,5 @@
 import { ClassList } from "~/types/jsxAttributes";
-import { isArray, isString } from "./types";
+import { isArray, isObject, isString } from "./types";
 import { Signal } from "@builder.io/qwik";
 
 export const serializeClass = (obj: ClassList | Signal<ClassList>): string => {
@@ -16,7 +16,9 @@ export const serializeClass = (obj: ClassList | Signal<ClassList>): string => {
         : result;
     }, "");
 
-  return Object.entries(obj.value ? obj.value : obj).reduce(
+  return Object.entries(
+    obj.value && isObject(obj.value) ? obj.value : obj
+  ).reduce(
     (result, [key, value]) =>
       value ? (result ? `${result} ${key.trim()}` : key.trim()) : result,
     ""


### PR DESCRIPTION
`serializeClass` was prone to Signal<ClassList> and class name collision. If we provide { value: true } as a valid format to the serialization, the result would be incorrect.
This fix check whenever the `value` key is an object or not. This is a handle case for Signal<ClassList>.